### PR TITLE
Namespace

### DIFF
--- a/src/GMaps.css
+++ b/src/GMaps.css
@@ -1,0 +1,14 @@
+.GMap {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}
+.GMap-canvas {
+  top: 20px;
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.UpdatedText {
+  color: red;
+}

--- a/src/GMaps.js
+++ b/src/GMaps.js
@@ -1,16 +1,14 @@
 import React, { Component } from 'react';
 import './GMaps.css';
 import loadJS from './vendor/loadJS';
+var google, map
 
 export const initialCenter = { lng: -90.1056957, lat: 29.9717272 }
 export class GMap extends Component {
-  state = { zoom: 10 };
-
-  componentWillMount() {
-    loadJS('https://maps.googleapis.com/maps/api/js?key=AIzaSyCZwgsigsvot5FGN3gdXa3gUOU5tjMDWzw');
-    console.log('componentWillMount complete');
-  }
-
+  constructor(props) {
+      super(props);
+      this.state = { zoom: 10 };
+    }
 	render() {
     return <div className="GMap">
       <div className='UpdatedText'>
@@ -22,7 +20,9 @@ export class GMap extends Component {
   }
 
   componentDidMount() {
-
+    loadJS('https://maps.googleapis.com/maps/api/js?key=AIzaSyCZwgsigsvot5FGN3gdXa3gUOU5tjMDWzw&callback=createMap');
+    window.google = this.google;
+    window.map = this.map;
     // create the map, marker and infoWindow after the component has
     // been rendered because we need to manipulate the DOM for Google =(
     this.map = this.createMap()

--- a/src/GMaps.js
+++ b/src/GMaps.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import './GMaps.css';
-import loadJS from './vendor/loadJS';
-var google, map
+// import loadJS from './vendor/loadJS';
+//these don't have any values; the page might render but the map won't work unless they are given values
 
 export const initialCenter = { lng: -90.1056957, lat: 29.9717272 }
 export class GMap extends Component {
@@ -9,6 +9,8 @@ export class GMap extends Component {
       super(props);
       this.state = { zoom: 10 };
     }
+
+
 	render() {
     return <div className="GMap">
       <div className='UpdatedText'>
@@ -20,9 +22,6 @@ export class GMap extends Component {
   }
 
   componentDidMount() {
-    loadJS('https://maps.googleapis.com/maps/api/js?key=AIzaSyCZwgsigsvot5FGN3gdXa3gUOU5tjMDWzw&callback=createMap');
-    window.google = this.google;
-    window.map = this.map;
     // create the map, marker and infoWindow after the component has
     // been rendered because we need to manipulate the DOM for Google =(
     this.map = this.createMap()

--- a/src/GMaps.js
+++ b/src/GMaps.js
@@ -2,8 +2,12 @@ import React, { Component } from 'react';
 import './GMaps.css';
 // import loadJS from './vendor/loadJS';
 //these don't have any values; the page might render but the map won't work unless they are given values
+let google, map
+if(!google) {
+  google = window.google;
+}
 
-export const initialCenter = { lng: -90.1056957, lat: 29.9717272 }
+export const initialCenter = { lng: -122.335167, lat: 47.608013 }
 export class GMap extends Component {
   constructor(props) {
       super(props);
@@ -62,7 +66,7 @@ export class GMap extends Component {
 	}
 
   createInfoWindow() {
-    let contentString = "<div class='InfoWindow'>I'm a Window that contains Info Yay</div>"
+    let contentString = "<div class='InfoWindow'>I'm an info window!</div>"
     return new google.maps.InfoWindow({
       map: this.map,
       anchor: this.marker,

--- a/src/GMaps.js
+++ b/src/GMaps.js
@@ -8,7 +8,7 @@ export class GMap extends Component {
 
   componentWillMount() {
     loadJS('https://maps.googleapis.com/maps/api/js?key=AIzaSyCZwgsigsvot5FGN3gdXa3gUOU5tjMDWzw');
-    console.log('componentWillMount probably ran loadJS');
+    console.log('componentWillMount complete');
   }
 
 	render() {
@@ -32,6 +32,7 @@ export class GMap extends Component {
     // have to define google maps event listeners here too
     // because we can't add listeners on the map until its created
     google.maps.event.addListener(this.map, 'zoom_changed', ()=> this.handleZoomChange())
+    console.log('componentDidMount complete');
   }
 
   // clean up event listeners when component unmounts

--- a/src/GMaps.js
+++ b/src/GMaps.js
@@ -1,8 +1,15 @@
 import React, { Component } from 'react';
 import './GMaps.css';
+import loadJS from './vendor/loadJS';
 
-class GMap extends Component {
+export const initialCenter = { lng: -90.1056957, lat: 29.9717272 }
+export class GMap extends Component {
   state = { zoom: 10 };
+
+  componentWillMount() {
+    loadJS('https://maps.googleapis.com/maps/api/js?key=AIzaSyCZwgsigsvot5FGN3gdXa3gUOU5tjMDWzw');
+    console.log('componentWillMount probably ran loadJS');
+  }
 
 	render() {
     return <div className="GMap">
@@ -15,6 +22,7 @@ class GMap extends Component {
   }
 
   componentDidMount() {
+
     // create the map, marker and infoWindow after the component has
     // been rendered because we need to manipulate the DOM for Google =(
     this.map = this.createMap()
@@ -68,6 +76,3 @@ class GMap extends Component {
     })
   }
 }
-
-export default GMap
-export const initialCenter = { lng: -90.1056957, lat: 29.9717272 }

--- a/src/vendor/loadJS.js
+++ b/src/vendor/loadJS.js
@@ -1,0 +1,22 @@
+/*! loadJS: load a JS file asynchronously. [c]2014 @scottjehl, Filament Group, Inc. (Based on http://goo.gl/REQGQ by Paul Irish). Licensed MIT */
+(function( w ){
+	var loadJS = function( src, cb ){
+		"use strict";
+		var ref = w.document.getElementsByTagName( "script" )[ 0 ];
+		var script = w.document.createElement( "script" );
+		script.src = src;
+		script.async = true;
+		ref.parentNode.insertBefore( script, ref );
+		if (cb && typeof(cb) === "function") {
+			script.onload = cb;
+		}
+		return script;
+	};
+	// commonjs
+	if( typeof module !== "undefined" ){
+		module.exports = loadJS;
+	}
+	else {
+		w.loadJS = loadJS;
+	}
+}( typeof global !== "undefined" ? global : this ));

--- a/src/vendor/loadJS.js
+++ b/src/vendor/loadJS.js
@@ -1,7 +1,6 @@
 /*! loadJS: load a JS file asynchronously. [c]2014 @scottjehl, Filament Group, Inc. (Based on http://goo.gl/REQGQ by Paul Irish). Licensed MIT */
-(function( w ){
+export default function() { (function( w ){
 	var loadJS = function( src, cb ){
-		"use strict";
 		var ref = w.document.getElementsByTagName( "script" )[ 0 ];
 		var script = w.document.createElement( "script" );
 		script.src = src;
@@ -20,3 +19,4 @@
 		w.loadJS = loadJS;
 	}
 }( typeof global !== "undefined" ? global : this ));
+}


### PR DESCRIPTION
This renders a map, so, it works as MVP - however it requires a little work. If you have a google maps API key, add it to `public/index.html` replacing the string `YOUR_API_KEY_HERE` in line 7.

Fixes #1.

Raises some other issues, notably investigating if there are better ways to load the gmaps script, and/or holding the API key privately. 

Assuming I didn't break anything horribly, using the repo in its current state should render the Create React App header, red-text current zoom information, and a map window. By default, the map should render centered on Seattle and a pin with an info window telling you "I'm an info window!" on the map centerpoint.

note: for now loadJS is commented out but not removed from the repo. As part of investigating load issues I'll remove that if required in a future PR.