### PR TITLE
Keylocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,7 @@
 
 # production
 /build
-
-# development
-googleapikey.js
+gMapAPI.js
 
 # misc
 .DS_Store

--- a/public/gMapAPI.js
+++ b/public/gMapAPI.js
@@ -1,0 +1,3 @@
+var apiWithKey = document.createElement('script');
+apiWithKey.src = 'https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE';
+document.head.appendChild(apiWithKey);

--- a/public/index.html
+++ b/public/index.html
@@ -4,17 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY_HERE"></script>
-    <!--
-      Notice the use of %PUBLIC_URL% in the tag above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <script src="gMapAPI.js"></script> <!-- If you don't want to use this obfuscation (you probably do not want to) replace this line with the google maps script tag directly -->
+    <title>Google Maps / Create React App</title>
   </head>
   <body>
     <div id="root">


### PR DESCRIPTION
"Fixes" #7 

This is really not solvable with obfuscating the key location - the key needs to be sent to Google so any debug/dev tool can tell you what it is easily enough and the best way to limit the potential API key abuse is to use Google's auth tools for your given project or env values outside the scope of this repo. Hence the quotes around "fixes" ... what this does is help me keep my repo clean, but it's adding code complexity for little/no benefit for you.

So, two ways to get your Google Maps API key into your code: 

 - There is a template gMapAPI.js provided in /public/. Replace `YOUR_KEY_HERE` with your Google Maps API key. 
 - delete gMapAPI.js and in index.html, replace line 7, `<script src="gMapAPI.js"></script>` with `<script src="https://maps.googleapis.com/maps/api/js?key=YOUR_KEY_HERE"></script>`


